### PR TITLE
Update regex to match additional GitHub pull request paths

### DIFF
--- a/with_whitespace.js
+++ b/with_whitespace.js
@@ -1,7 +1,7 @@
 (() => {
 	const addQueryParam = () => {
 		const prPageRegex =
-			/^https:\/\/github.com\/([^\/]+)\/([^\/]+)\/pull\/\d+\/(files|commits\/\w)/;
+			/^https:\/\/github.com\/([^\/]+)\/([^\/]+)\/pull\/\d+\/(files|commits|changes\/\w)/;
 		const match = window.location.href.match(prPageRegex);
 		if (!match) {
 			return;


### PR DESCRIPTION
The path for the file changes page has been updated to /changes, so this PR reflects that change.

Example: https://github.com/uewtwo/hide-whitespace-on-github-pr/pull/1/changes

Note: Haven't tested this yet, sorry about that!